### PR TITLE
Update

### DIFF
--- a/TBetaGenerator.hpp
+++ b/TBetaGenerator.hpp
@@ -19,8 +19,8 @@ namespace TBeta
   static constexpr double gA        = 1.2646;             // nucleon axial coupling
   static constexpr double gAq       = 1.24983;            // quenched gA
   static constexpr double gV        = 1.0;                // nucleon vector coupling
-  static constexpr double MTr       = 2808921.13668;      // [C1] bare nuclear tritium mass [keV]
-  static constexpr double Mf        = 2808391.61112;      // [C1] bare nuclear 3He+ mass [keV]
+  static constexpr double MTr       = 2808921.1367789;    // [C2] bare nuclear tritium mass [keV]
+  static constexpr double Mf        = 2808391.6111557;    // [C2] bare nuclear 3He+ mass [keV]
   static constexpr double alpha     = 7.2973525643e-3;    // [C1] ine structure constant
   static constexpr double Gf        = 1.1663787e-17;      // Fermi interaction strength [keV^-2]
   static constexpr double Rn        = 2.884e-3;           // nuclear radius of 3He [me]

--- a/TBetaGenerator.hpp
+++ b/TBetaGenerator.hpp
@@ -8,17 +8,20 @@
 #include <complex>
 #include <functional>
 
+// references for value updates:
+// [C1] CODATA 2022: P.J. Mohr et al, Rev. Mod. Phys. 97 (2025) 025002
+// [C2] M.M. Restrepo and E.G. Myers, PRL 131 (2023) 243002
 namespace TBeta
 {
   static constexpr double pi        = std::acos(-1.0);    // Pi
   static constexpr double twopi     = 2.0 * pi;           // 2 Pi
-  static constexpr double me        = 510.99895;          // electron mass [keV]
+  static constexpr double me        = 510.99895069;       // [C1] electron mass [keV]
   static constexpr double gA        = 1.2646;             // nucleon axial coupling
   static constexpr double gAq       = 1.24983;            // quenched gA
   static constexpr double gV        = 1.0;                // nucleon vector coupling
-  static constexpr double MTr       = 2808920.8205;       // bare nuclear tritium mass [keV]
-  static constexpr double Mf        = 2808391.2193;       // bare nuclear 3He+ mass [keV]
-  static constexpr double alpha     = 7.2973525693e-3;    // fine structure constant
+  static constexpr double MTr       = 2808921.13668;      // [C1] bare nuclear tritium mass [keV]
+  static constexpr double Mf        = 2808391.61112;      // [C1] bare nuclear 3He+ mass [keV]
+  static constexpr double alpha     = 7.2973525643e-3;    // [C1] ine structure constant
   static constexpr double Gf        = 1.1663787e-17;      // Fermi interaction strength [keV^-2]
   static constexpr double Rn        = 2.884e-3;           // nuclear radius of 3He [me]
   static constexpr double keVInvSec = 1.52e18;            // conversion [keV s]

--- a/TBetaGenerator.hpp
+++ b/TBetaGenerator.hpp
@@ -47,7 +47,7 @@ namespace TBeta
   //
 
   // heaviside function
-  inline double heavyside(double x){
+  double heavyside(double x){
     double result;
     if (x>0.0) result = 1.0;
     else if (x==0.0) result = 0.5;
@@ -110,23 +110,15 @@ namespace TBeta
   // [1] Preprint arXiv 1806.00369
   // [2] PRL 5(85) 807
 
-    // 3-body endpoint energy of bare tritium [keV] (neutrino mass munu [keV])
-    inline double endpoint(double munu) {
-        double m2    = MTr*MTr;
-        double me2   = me*me;
-        double msum2 = (Mf+munu)*(Mf+munu);
-        return (m2 + me2 - msum2)/(2.0*MTr) - me;
-    }
-
     // Atomic 3He mass including n-th energy level binding
-    inline double MfAt(int n){
+    double MfAt(int n){
         if (n<1) n=1; // remove illegal n values
         return Mf + me - 4.0*Ryd/(n*n);
     }
 
     // 3-body endpoint energy of atomic tritium [keV] (neutrino mass [keV])
     // and energy level n
-    inline double endAt(double munu, int n){
+    double endAt(double munu, int n){
         double mat2  = MAt*MAt;
         double me2   = me*me;
         double matn  = MfAt(n);
@@ -135,7 +127,7 @@ namespace TBeta
     }
 
     // Simpson approximation of Fermi function [1] (A.2)
-    inline double Fermi(int Z, double beta) {
+    double Fermi(int Z, double beta) {
         double eta   = alpha * Z / beta; // Sommerfeld parameter
         double nom   = twopi * eta * (1.002037 - 0.001427*beta);
         double denom = 1.0-std::exp(-twopi * eta);
@@ -143,7 +135,7 @@ namespace TBeta
     }
 
   // Radiative correction [1] (A.3)
-  inline double G(double en, double endp) {
+  double G(double en, double endp) {
     if (endp<=en) return 0.0;
     if (en<0.04) en = 0.04; // avoid zero energy
     double w  = (en + me) / me; // total electron energy [me]
@@ -159,7 +151,7 @@ namespace TBeta
   }
 
   // Orbital electron shielding [1] (A.4)
-  inline double S(int Z, double en) {
+  double S(int Z, double en) {
     if (en<0.04) en = 0.04; // check announced anomaly
     static constexpr double v0 = 1.45*alpha*alpha * me; // =76 eV in ref [1]
     double w  = (en + me) / me; // total electron energy [me]
@@ -177,7 +169,7 @@ namespace TBeta
   }
   
   // Scaling od the electric field within nucleus [1] (A.7)
-  inline double L(int Z, double en) {
+  double L(int Z, double en) {
     double w  = (en + me) / me; // total electron energy [me]
     double fac = alpha * Z;
     double gamma = std::sqrt(1.0-fac*fac);
@@ -187,7 +179,7 @@ namespace TBeta
   }
   
   // Convolution of electron and neutrino wavefunctions within nucleus [1] (A.8)
-  inline double CC(int Z, double en, double endp) {
+  double CC(int Z, double en, double endp) {
     if (endp<=en) return 1.0;
     double w  = (en + me) / me; // total electron energy [me]
     double w0 = (endp + me) / me;
@@ -200,7 +192,7 @@ namespace TBeta
   
 
     // Recoiling nuclear charge field [1] (A.9)
-  inline double Q(int Z, double en, double endp) {
+  double Q(int Z, double en, double endp) {
     if (endp<=en) return 1.0;
     if (en<0.04) en = 0.04; // avoid zero energy
     static const double mcc = 5497.885;
@@ -215,7 +207,7 @@ namespace TBeta
   // Combined correction factor for atomic tritium
   // function of neutrino mass munu [keV], n atomic energy level
   // of daughter nucleus, en electron energy [kev]
-  inline double Corr(double en, double munu, int n) {
+  double Corr(double en, double munu, int n) {
     double arg = std::sqrt((en+me)*(en+me)-me*me)/(en+me);
     double e0 = endAt(munu, n);
     if (e0<=en) return 1.0; // no correction
@@ -225,7 +217,7 @@ namespace TBeta
   // Differential decay rate with energy en [kev], applicable to LH SM currents
   // for the emission of an electron antineutrino with mass munu [kev] and 
   // the endpoint of the n-th 3He energy level. With corrections.
-  inline double stub(double en, double munu, double e0) { // used twice, factor out
+  double stub(double en, double munu, double e0) { // used twice, factor out
     if (e0<en) return 0.0;
     double fac1  = (Gf*Gf*Vud*Vud)/(2.0*pi*pi*pi);
     double denom = MTr*MTr - 2.0*MTr*(en+me) + me*me;
@@ -246,7 +238,7 @@ namespace TBeta
     return fac1*(term1+term2+term3);
   }
 
-    inline double Diff(double en, double munu, int n) {
+    double Diff(double en, double munu, int n) {
         double e0 = endAt(munu, n);
         double fac = stub(en, munu, e0);
         return fac * Corr(en,munu,n);
@@ -255,7 +247,7 @@ namespace TBeta
   // neutrino mass spectrum
   // order is boolean True for Normal order (NO)
   // False for Inverted order (IO)
-  const inline std::array<double,3>& nuSpectrum(bool order, double munu) {
+  const std::array<double,3>& nuSpectrum(bool order, double munu) {
     static const std::array<double,3> no = {munu, std::sqrt(munu*munu+dm21Sq), std::sqrt(munu*munu+dm31Sq)};
     static const std::array<double,3> io = {std::sqrt(munu*munu-dm21Sq-dm32Sq), std::sqrt(munu*munu-dm32Sq), munu};
     return order ? no : io;
@@ -264,7 +256,7 @@ namespace TBeta
   // like Diff but summing over all three light neutrinos with weights.
   // order is boolean True for Normal order (NO)
   // False for Inverted order (IO)
-  inline double Diff3nu(bool order, double en, double munu, int n) {
+  double Diff3nu(bool order, double en, double munu, int n) {
     const std::array<double,3>& UeSq = order ? UeSqNO : UeSqIO;
     double  sum  = 0.0;
     for (int i=0;i<3;++i) {
@@ -276,26 +268,26 @@ namespace TBeta
     // like Diff but summing over all three light neutrinos with weights and
     // a sterile neutrino with mass mN [keV] with active-sterile mixing
     // strength eta (0<=eta<1)
-    inline double Diff4nu(bool order, double mN, double eta, double en, double munu, int n) {
+    double Diff4nu(bool order, double mN, double eta, double en, double munu, int n) {
         double e0 = endAt(mN, n);
         return (1.0-eta*eta)*Diff3nu(order, en, munu, n) + eta*eta*Diff(en, mN, n)*heavyside(e0-en);
     }
 
     // Sum over discrete atomic energy levels of 3He
     // with branching ratios, [2]
-    inline double etaL(double en) {
+    double etaL(double en) {
         double denom  = (en+me)*(en+me) - me*me;
         return -2.0*alpha*me/std::sqrt(denom);
     }
 
-    inline double aL(double en) {
+    double aL(double en) {
         double eta = etaL(en);
         double nom = std::exp(2.0*eta*std::atan(-2.0/eta));
         double denom = (1.0 + eta*eta/4.0)*(1.0 + eta*eta/4.0);
         return eta*eta*eta*eta*nom/denom;
     }
 
-    inline double Lev(int n, double en) {
+    double Lev(int n, double en) {
         double al = aL(en);
         if (n==2) // special case
             return 0.25 * (1.0 + al*al - al);
@@ -307,7 +299,7 @@ namespace TBeta
     // Full (SM+sterile) differential decay rate as function of electron energy [keV].
     // Includes all corrections (no continuum orbital e- states) and 
     // the first 5 bound discrete atomic states.
-    inline double dGammadE(bool order, double munu, double mN, double eta, double en) {
+    double dGammadE(bool order, double munu, double mN, double eta, double en) {
         double sum = 0.0;
         for (int n=1;n<=5;++n)
             sum += Lev(n, en) * Diff4nu(order, mN, eta, en, munu, n);
@@ -316,25 +308,25 @@ namespace TBeta
 
     // Set up all contributions including continous states and first 5 
     // discrete states. Here consider state n as double for continuum states.
-    inline double endCont(double munu, double n) {
+    double endCont(double munu, double n) {
         return endAt(munu, 1)-4.0*Ryd*(1.0+1.0/(n*n));
     }
 
-    inline double CorrCont(double en, double munu, double n) {
+    double CorrCont(double en, double munu, double n) {
         double e0 = endCont(munu, n);
         double nom  = (en+me)*(en+me) - me*me;
         double fac = Fermi(2,std::sqrt(nom)/(en+me))*S(2,en)*G(en,e0);
         return fac*L(2,en)*CC(2,en,e0)*Q(2,en,e0);
     }
 
-    inline double DiffCont(double en, double munu, double n) {
+    double DiffCont(double en, double munu, double n) {
         double e0 = endCont(munu, n);
         double fac = stub(en, munu, e0);
         return fac * CorrCont(en, munu, n);
     }
 
     // integrand over states g
-    inline double integrand(double g, double en, double munu) {
+    double integrand(double g, double en, double munu) {
         double fac1 = DiffCont(en, munu, g)*twopi/(g*g*g*(std::exp(twopi*g)-1.0));
         double fac2 = g*g*g*g*std::exp(2.0*g*std::atan(-2.0/g))/((1.0+g*g/4.0)*(1.0+g*g/4.0));
         return fac1*(fac2*fac2 + aL(en)*aL(en) - aL(en)*fac2);
@@ -342,14 +334,14 @@ namespace TBeta
 
     // Contribution only from the continuum orbital electron states.
     // integrate over g.
-    inline double gammaCont(double en, double munu) {
+    double gammaCont(double en, double munu) {
         if (en > endCont(munu, 1e10)) return 0.0;
         std::function<double(double,double,double)> fn = integrand;
         SimpsonIntegral sint(fn, en, munu);
         return sint.integrate(-99, etaL(en), 1000)/pi;
     }
 
-  inline double dGammadECont(bool order, double munu, double mN, double eta, double en) {
+  double dGammadECont(bool order, double munu, double mN, double eta, double en) {
     const std::array<double,3>& UeSq = order ? UeSqNO : UeSqIO;
     double sum = 0.0;
     for (int i=0;i<3;++i) {
@@ -358,7 +350,7 @@ namespace TBeta
     return (1-eta*eta)*sum + eta*eta*gammaCont(en, mN);
   }
 
-  inline double dGammadEFull(bool order, double munu, double mN, double eta, double en) {
+  double dGammadEFull(bool order, double munu, double mN, double eta, double en) {
     return dGammadE(order, munu, mN, eta, en) + dGammadECont(order, munu, mN, eta, en);
   }
 } // namespace TBeta

--- a/examples/generatorExample.cpp
+++ b/examples/generatorExample.cpp
@@ -53,7 +53,8 @@ int main() {
   
   pld_type ed(nw, lbound, ubound, betaGenerator(order, mnu, mN, eta));
 
-  std::cout << "endpoint energy mnu=0: " << TBeta::endAt(0.0,1) << std::endl;
+  std::cout << "endpoint energy mnu=0: " << TBeta::endpoint(0.0) << std::endl;
+  std::cout << "endAt energy mnu=0: " << TBeta::endAt(0.0,1) << std::endl;
   std::cout << "energy intervals:" << std::endl;
   for (double val : ed.intervals()) std::cout << val << " ";
   std::cout << std::endl;

--- a/examples/generatorExample.cpp
+++ b/examples/generatorExample.cpp
@@ -53,7 +53,8 @@ int main() {
   
   pld_type ed(nw, lbound, ubound, betaGenerator(order, mnu, mN, eta));
 
-  std::cout<< "energy intervals:" << std::endl;
+  std::cout << "endpoint energy mnu=0: " << TBeta::endAt(0.0,1) << std::endl;
+  std::cout << "energy intervals:" << std::endl;
   for (double val : ed.intervals()) std::cout << val << " ";
   std::cout << std::endl;
 

--- a/examples/generatorExample.cpp
+++ b/examples/generatorExample.cpp
@@ -53,8 +53,10 @@ int main() {
   
   pld_type ed(nw, lbound, ubound, betaGenerator(order, mnu, mN, eta));
 
-  std::cout << "endpoint energy mnu=0: " << TBeta::endpoint(0.0) << std::endl;
-  std::cout << "endAt energy mnu=0: " << TBeta::endAt(0.0,1) << std::endl;
+  double qvalue = TBeta::endAt(0.0, 1);
+  std::cout << "endAt energy mnu=0: " << qvalue << std::endl;
+  std::cout << "compared to published 18.592071(22) keV; corrections: He-1s binding energy and He-3 recoil energy: " << std::endl;
+  std::cout << (18.592071-qvalue)*1000 << " eV" << std::endl;
   std::cout << "energy intervals:" << std::endl;
   for (double val : ed.intervals()) std::cout << val << " ";
   std::cout << std::endl;

--- a/examples/test2.cpp
+++ b/examples/test2.cpp
@@ -12,23 +12,15 @@ int main() {
   double mnu = 1.e-4; // 0.1 eV
   double en  = 18.5; // keV
   double endp = TBeta::endAt(mnu, 1);
-  double bare = TBeta::endpoint(mnu);
 
   std::cout.precision(10);
   // endpoints
-  std::cout << "tbeta bare endpoint at mnu=0.1: " << bare << std::endl;
   std::cout << "tbeta end at mnu=0.1, n=1: " << endp << std::endl;
   std::cout << "tbeta end at mnu=0.1, n=2: " << TBeta::endAt(mnu, 2) << std::endl;
   std::cout << "tbeta end at mnu=0.1, n=3: " << TBeta::endAt(mnu, 3) << std::endl;
   std::cout << std::endl;
 
   // corrections
-  std::cout << "G-1 ppm at e=0.04; mnu=0.1: " << (TBeta::G(0.0, bare)-1.0)*1e6 << std::endl;
-  std::cout << "G-1 ppm at e=1; mnu=0.1: " << (TBeta::G(1.0, bare)-1.0)*1e6 << std::endl;
-  std::cout << "G-1 ppm at e=5; mnu=0.1: " << (TBeta::G(5.0, bare)-1.0)*1e6 << std::endl;
-  std::cout << "G-1 ppm at e=endp; mnu=0.1: " << (TBeta::G(endp, bare)-1.0)*1e6 << std::endl;
-  std::cout << std::endl;
-
   std::cout << "S-1 ppm at e=0.04; mnu=0.1: " << (TBeta::S(2, 0.04)-1.0)*1e6 << std::endl;
   std::cout << "S-1 ppm at e=0.1; mnu=0.1: " << (TBeta::S(2, 0.1)-1.0)*1e6 << std::endl;
   std::cout << "S-1 ppm at e=0.2; mnu=0.1: " << (TBeta::S(2, 0.2)-1.0)*1e6 << std::endl;
@@ -36,18 +28,6 @@ int main() {
   std::cout << "S-1 ppm at e=1; mnu=0.1: " << (TBeta::S(2, 1.0)-1.0)*1e6 << std::endl;
   std::cout << "S-1 ppm at e=5; mnu=0.1: " << (TBeta::S(2, 5.0)-1.0)*1e6 << std::endl;
   std::cout << "S-1 ppm at e=endp; mnu=0.1: " << (TBeta::S(2, endp)-1.0)*1e6 << std::endl;
-  std::cout << std::endl;
-
-  std::cout << "LCC-1 ppm at e=0.04; mnu=0.1: " << (TBeta::L(2, 0.0)*TBeta::CC(2, 0.0, bare)-1.0)*1e6 << std::endl;
-  std::cout << "LCC-1 ppm at e=1; mnu=0.1: " << (TBeta::L(2, 1.0)*TBeta::CC(2, 1.0, bare)-1.0)*1e6 << std::endl;
-  std::cout << "LCC-1 ppm at e=5; mnu=0.1: " << (TBeta::L(2, 5.0)*TBeta::CC(2, 5.0, bare)-1.0)*1e6 << std::endl;
-  std::cout << "LCC-1 ppm at e=endp; mnu=0.1: " << (TBeta::L(2, endp)*TBeta::CC(2, endp, bare)-1.0)*1e6 << std::endl;
-  std::cout << std::endl;
-
-  std::cout << "Q-1 ppm at e=0.04; mnu=0.1: " << (TBeta::Q(2, 0.0, bare)-1.0)*1e6 << std::endl;
-  std::cout << "Q-1 ppm at e=1; mnu=0.1: " << (TBeta::Q(2, 1.0, bare)-1.0)*1e6 << std::endl;
-  std::cout << "Q-1 ppm at e=5; mnu=0.1: " << (TBeta::Q(2, 5.0, bare)-1.0)*1e6 << std::endl;
-  std::cout << "Q-1 ppm at e=endp; mnu=0.1: " << (TBeta::Q(2, endp, bare)-1.0)*1e6 << std::endl;
   std::cout << std::endl;
 
   bool order = true;


### PR DESCRIPTION
new reference data values entered and tested: references C1 and C2 in source code are CODATA 2022 publ. in March 2025 and new Q-value measurements with Triton and Helion masses published in 2023.
Redundant 'inline' keyword removed.
Short explaining text output for decay energy endpoint in generatorTest example.
